### PR TITLE
Add entrypoint script and env file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 *
+!entrypoint.sh
 !release/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,18 @@
 # docker build --rm -t drone/drone .
 
-FROM drone/ca-certs
+FROM alpine:3.7
+RUN apk add --update --no-cache ca-certificates \
+ && mkdir -p /etc/drone \
+ && rm -rf /var/cache/apk/*
+
 EXPOSE 8000 9000 80 443
 
+ENV DRONE_ENV_FILE=/etc/drone/env
 ENV DATABASE_DRIVER=sqlite3
 ENV DATABASE_CONFIG=/var/lib/drone/drone.sqlite
 ENV GODEBUG=netdns=go
 ENV XDG_CACHE_HOME /var/lib/drone
 
-ADD release/drone-server /bin/
+ADD release/drone-server entrypoint.sh /bin/
 
-ENTRYPOINT ["/bin/drone-server"]
+ENTRYPOINT ["/bin/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+
+if [ -n "${DRONE_ENV_FILE}" ]; then
+  while [ ! -f "${DRONE_ENV_FILE}" ]; do sleep 2; done
+  source ${DRONE_ENV_FILE}
+fi
+
+exec /bin/drone-server


### PR DESCRIPTION
This allows for ENV vars to be bound from a volume mount.

The env file should contain lines in this format:
```
export ENV_VAR_NAME=value
```

This file is sourced by the entrypoint script if it exists and the DRONE_ENV_FILE var is set.